### PR TITLE
Fix and update for wildcards

### DIFF
--- a/wildcards.py
+++ b/wildcards.py
@@ -136,8 +136,8 @@ class wildcards:
         #print(f"files : {files}")
         
         for file in files:
-            basename = os.path.basename(file)
-            file_name = os.path.splitext(basename)[0]
+            basename = os.path.relpath(file, os.path.dirname(__file__))
+            file_name = os.path.splitext(basename)[0].replace("../../wildcards/", "")
             if not file_name in cards:
                 cards[file_name]=[]
             #print(f"file_name : {file_name}")

--- a/wildcards.py
+++ b/wildcards.py
@@ -14,7 +14,7 @@ else:
 class wildcards:
 
     # 가져올 파일 목록
-    card_path=os.path.dirname(__file__)+"\\..\\..\\wildcards\\**\\*.txt"
+    card_path=os.path.dirname(__file__)+"/../../wildcards/**/*.txt"
     #card_path=f"{os.getcwd()}\\wildcards\\**\\*.txt"
     print(f"wildcards card_path : ", card_path , style="bold CYAN")
 


### PR DESCRIPTION
Hi.

First commit fixes `card_path` variable. I don't know if "\\\\..\\\\..\\\\" works on Windows, but on Linux it doesn't work. New variation works both on Linux and Windows.

Second commit adds subfolders support. So, wildcard files can have same name and be in different subfolders, like:

```
../haircolor.txt
../fantasy/haircolor.txt
../fantasy/weird/haircolor.txt
```

And in comfyui you can call them with `__haircolor__`, `__fantasy/haircolor__`, `__fantasy/weird/haircolor__`.