### PR TITLE
Make it work both on Linux and Windws + subfolders support

### DIFF
--- a/wildcards.py
+++ b/wildcards.py
@@ -14,7 +14,7 @@ else:
 class wildcards:
 
     # 가져올 파일 목록
-    card_path=os.path.dirname(__file__)+"/../../wildcards/**/*.txt"
+    card_path = os.path.join(os.path.dirname(__file__), "..", "..", "wildcards", "**", "*.txt")
     #card_path=f"{os.getcwd()}\\wildcards\\**\\*.txt"
     print(f"wildcards card_path : ", card_path , style="bold CYAN")
 
@@ -136,8 +136,8 @@ class wildcards:
         #print(f"files : {files}")
         
         for file in files:
-            basename = os.path.relpath(file, os.path.dirname(__file__))
-            file_name = os.path.splitext(basename)[0].replace("../../wildcards/", "")
+            basename =  os.path.relpath(file, os.path.dirname(__file__)).replace("\\", "/").replace("../../wildcards/", "")
+            file_name = os.path.splitext(basename)[0]
             if not file_name in cards:
                 cards[file_name]=[]
             #print(f"file_name : {file_name}")

--- a/wildcards.py
+++ b/wildcards.py
@@ -136,8 +136,8 @@ class wildcards:
         #print(f"files : {files}")
         
         for file in files:
-            basename = os.path.basename(file)
-            file_name = os.path.splitext(basename)[0]
+            basename = os.path.relpath(file, os.path.dirname(__file__))
+            file_name = os.path.splitext(basename)[0].replace("../../wildcards/", "")
             if not file_name in cards:
                 cards[file_name]=[]
             #print(f"file_name : {file_name}")

--- a/wildcards.py
+++ b/wildcards.py
@@ -14,7 +14,7 @@ else:
 class wildcards:
 
     # 가져올 파일 목록
-    card_path=os.path.dirname(__file__)+"\\..\\..\\wildcards\\**\\*.txt"
+    card_path=os.path.dirname(__file__)+"/../../wildcards/**/*.txt"
     #card_path=f"{os.getcwd()}\\wildcards\\**\\*.txt"
     print(f"wildcards card_path : ", card_path , style="bold CYAN")
 


### PR DESCRIPTION
Hi.

Wildcard files didn't work on Linux for me. I made couple changes, now it works both on Windows and Linux.

Plus now .txt files may be places in subfolders and called like so: `__subfolder1/filename__ __subfolder2/filename__`.
