### PR TITLE
Use ComfyUI folder locations

### DIFF
--- a/CheckpointLoaderSimpleText.py
+++ b/CheckpointLoaderSimpleText.py
@@ -36,7 +36,7 @@ class CheckpointLoaderSimpleText:
     
     def load_checkpoint(self, ckpt_name, output_vae=True, output_clip=True):
         print(f"[{ccolor}]ckpt_name : [/{ccolor}]", ckpt_name)
-        ckpt_path=getFullPath(ckpt_name,"checkpoints")
+        ckpt_path=folder_paths.get_full_path("checkpoints", ckpt_name)
         try:
             out = comfy.sd.load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, embedding_directory=folder_paths.get_folder_paths("embeddings"))
             return out


### PR DESCRIPTION
Update the CheckpointLoaderSimpleText to use ComfyUI folder_paths for file locations. Otherwise will cause error if models are located somewhere other than the default location.