### PR TITLE
Fix TextWildcards not disabling dynamicPrompts

### DIFF
--- a/TextWildcards.py
+++ b/TextWildcards.py
@@ -15,7 +15,7 @@ class TextWildcards:
     def INPUT_TYPES(s):
         return {
         "required": {
-            "text": ("STRING", {"multiline": True}),
+            "text": ("STRING", {"multiline": True, "dynamicPrompts": False}),
             "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
             
         }


### PR DESCRIPTION
ComfyUI has built-in dynamic prompts now, though they only support simple {a|b} and not the more advanced {2$$-$$a|b|c} dynamic prompts with nesting. In addition built-in dynamic prompts would overwrite the prompt in the field when trying to load generation info. By setting "dynamicPrompts" to False, we disable that functionality so this node can do it's job properly again.